### PR TITLE
Update firmware to 1.2.0

### DIFF
--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/mlm32l0xx_hw_conf.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/mlm32l0xx_hw_conf.h
@@ -105,8 +105,8 @@ extern "C" {
 #define RADIO_DIO_5_PORT                          GPIOA
 #define RADIO_DIO_5_PIN                           GPIO_PIN_4
 
-#define RADIO_TCXO_VCC_PORT                       GPIOA
-#define RADIO_TCXO_VCC_PIN                        GPIO_PIN_12
+#define RADIO_TCXO_VCC_PORT                       GPIOB
+#define RADIO_TCXO_VCC_PIN                        GPIO_PIN_6
 
 #define RADIO_ANT_SWITCH_PORT_RX                  GPIOA //CRF1
 #define RADIO_ANT_SWITCH_PIN_RX                   GPIO_PIN_1

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/version.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/version.h
@@ -72,7 +72,7 @@ extern "C" {
 #define TEST_VERSION (uint32_t) 0x00000000  /*1 lsb is always 0 in releases   */
 #define LRWAN_VERSION  (uint32_t) 0x00001120  /*3 next hex is i_cube release*/
 #define VERSION   (uint32_t) (LORA_MAC_VERSION | LRWAN_VERSION | TEST_VERSION)
-#define AT_VERSION_STRING	"1.1.9"
+#define AT_VERSION_STRING	"1.2.0"
 #define AT_DEVICE_STRING	"ARD-078"
 
 /* Exported types ------------------------------------------------------------*/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
@@ -236,6 +236,8 @@ static inline void runPassthrough() {
 		//"AND R4, R4, R6\n\t"
 		//"LSL R4, R4, #3\n\t"
 		"LSR R4, R7, #10\n\t"
+		// set TCXO pin to 1 forcefully (PB6)
+		"ADD R4, R4, #64\n\t"
 		"STR R4, [R1]\n\t"
 
 		"LSR R4, R7, #12\n\t"

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
@@ -201,24 +201,25 @@ void setupPassthrough() {
 	HW_GPIO_Init( GPIOB, GPIO_PIN_3, &initStruct );
 	HW_GPIO_Init( GPIOA, GPIO_PIN_7, &initStruct );
 	HW_GPIO_Init( GPIOA, GPIO_PIN_2, &initStruct );
-#ifdef USE_DIO0_IRQ
-	HW_GPIO_Init( GPIOB, GPIO_PIN_12, &initStruct );
-#endif
-	HW_GPIO_Init( GPIOB, GPIO_PIN_15, &initStruct );
+	HW_GPIO_Init( GPIOA, GPIO_PIN_15, &initStruct );
+	HW_GPIO_Init( GPIOA, GPIO_PIN_4, &initStruct );
+
+	// enable TCXO
+	initStruct.Pull = GPIO_PULLUP;
+	HW_GPIO_Init( RADIO_TCXO_VCC_PORT, RADIO_TCXO_VCC_PIN, &initStruct );
+	HW_GPIO_Write(RADIO_TCXO_VCC_PORT, RADIO_TCXO_VCC_PIN, 1);
 
 	// reset and SS pins
 	SX1276Reset();
 	HW_GPIO_Init( RADIO_NSS_PORT, RADIO_NSS_PIN, &initStruct );
-#ifdef USE_DIO0_IRQ
-	HW_GPIO_Write( RADIO_NSS_PORT, RADIO_NSS_PIN, 0 );
-#endif
 }
 
 static inline void runPassthrough() {
 	// PB13 -> PB3
 	// PA3 -> PA7
 	// PA6 -> PA2
-	// PB12 -> PB15
+	// PB12 -> PA15
+	// PB4 -> PA4
 
 	__asm__ volatile (
 		"LDR R0, =0x50000014\n\t"	//GPIOA_BSRR
@@ -240,6 +241,11 @@ static inline void runPassthrough() {
 		"LSR R4, R7, #12\n\t"
 		"AND R4, R4, R6\n\t"
 		"LSL R5, R4, #15\n\t"
+
+		"LSR R4, R7, #4\n\t"
+		"AND R4, R4, R6\n\t"
+		"LSL R4, R4, #4\n\t"
+		"ORR R5, R5, R4\n\t"
 
 		"LDR R7, [R2]\n\t"
 


### PR DESCRIPTION
Depends on https://github.com/sandeepmistry/arduino-LoRa/pull/297 for Lora passthrough (dumb mode) compatibility.

Still based on old ST firmware (while discussion on https://github.com/arduino-libraries/MKRWAN/issues/64 is ongoing)