### PR TITLE
ST fw update for band selection at runtime

### DIFF
--- a/Middlewares/Third_Party/LoRaWAN/Mac/LoRaMac.h
+++ b/Middlewares/Third_Party/LoRaWAN/Mac/LoRaMac.h
@@ -173,6 +173,53 @@
 #define LORAMAC_CRYPTO_MULTICAST_KEYS   127
 
 /*!
+ * LoRaMAC region enumeration
+ */
+typedef enum eLoRaMacRegion_t
+{
+    /*!
+     * AS band on 923MHz
+     */
+    LORAMAC_REGION_AS923,
+    /*!
+     * Australian band on 915MHz
+     */
+    LORAMAC_REGION_AU915,
+    /*!
+     * Chinese band on 470MHz
+     */
+    LORAMAC_REGION_CN470,
+    /*!
+     * Chinese band on 779MHz
+     */
+    LORAMAC_REGION_CN779,
+    /*!
+     * European band on 433MHz
+     */
+    LORAMAC_REGION_EU433,
+    /*!
+     * European band on 868MHz
+     */
+    LORAMAC_REGION_EU868,
+    /*!
+     * South korean band on 920MHz
+     */
+    LORAMAC_REGION_KR920,
+    /*!
+     * India band on 865MHz
+     */
+    LORAMAC_REGION_IN865,
+    /*!
+     * North american band on 915MHz
+     */
+    LORAMAC_REGION_US915,
+    /*!
+     * Russia band on 864MHz
+     */
+    LORAMAC_REGION_RU864,
+}LoRaMacRegion_t;
+
+/*!
  * End-Device activation type
  */
 typedef enum eActivationType
@@ -915,6 +962,10 @@ typedef struct sMcpsIndication
      * Set if a DeviceTimeAns MAC command was received.
      */
     bool DeviceTimeAnsReceived;
+    /*!
+     * Set the region currently in use
+     */
+    LoRaMacRegion_t Region;
 }McpsIndication_t;
 
 /*!
@@ -2244,52 +2295,6 @@ typedef enum eLoRaMacStatus
     LORAMAC_STATUS_ERROR
 }LoRaMacStatus_t;
 
-/*!
- * LoRaMAC region enumeration
- */
-typedef enum eLoRaMacRegion_t
-{
-    /*!
-     * AS band on 923MHz
-     */
-    LORAMAC_REGION_AS923,
-    /*!
-     * Australian band on 915MHz
-     */
-    LORAMAC_REGION_AU915,
-    /*!
-     * Chinese band on 470MHz
-     */
-    LORAMAC_REGION_CN470,
-    /*!
-     * Chinese band on 779MHz
-     */
-    LORAMAC_REGION_CN779,
-    /*!
-     * European band on 433MHz
-     */
-    LORAMAC_REGION_EU433,
-    /*!
-     * European band on 868MHz
-     */
-    LORAMAC_REGION_EU868,
-    /*!
-     * South korean band on 920MHz
-     */
-    LORAMAC_REGION_KR920,
-    /*!
-     * India band on 865MHz
-     */
-    LORAMAC_REGION_IN865,
-    /*!
-     * North american band on 915MHz
-     */
-    LORAMAC_REGION_US915,
-    /*!
-     * Russia band on 864MHz
-     */
-    LORAMAC_REGION_RU864,
-}LoRaMacRegion_t;
 
 /*!
  * Enumeration of modules which have a context

--- a/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/Core/inc/mlm32l0xx_hw_conf.h
+++ b/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/Core/inc/mlm32l0xx_hw_conf.h
@@ -78,8 +78,8 @@ extern "C" {
 #define RADIO_DIO_5_PORT                          GPIOA
 #define RADIO_DIO_5_PIN                           GPIO_PIN_4
 
-#define RADIO_TCXO_VCC_PORT                       GPIOA
-#define RADIO_TCXO_VCC_PIN                        GPIO_PIN_12
+#define RADIO_TCXO_VCC_PORT                       GPIOB
+#define RADIO_TCXO_VCC_PIN                        GPIO_PIN_6
 
 #define RADIO_ANT_SWITCH_PORT_RX                  GPIOA //CRF1
 #define RADIO_ANT_SWITCH_PIN_RX                   GPIO_PIN_1

--- a/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/inc/at.h
+++ b/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/inc/at.h
@@ -55,6 +55,7 @@ typedef enum eATEerror
 
 /* AT Command strings. Commands start with AT */
 #define AT_RESET      "Z"
+#define AT_BAND       "+BAND"
 #define AT_DEUI       "+DEUI"
 #define AT_DADDR      "+DADDR"
 #define AT_APPKEY     "+APPKEY"
@@ -130,6 +131,20 @@ ATEerror_t at_return_error(const char *param);
  * @retval AT_OK
  */
 ATEerror_t at_reset(const char *param);
+
+/**
+ * @brief  Print RF Band in use
+ * @param  Param string of the AT command
+ * @retval AT_OK if OK, or an appropriate AT_xxx error code
+ */
+ATEerror_t at_Band_get(const char *param);
+
+/**
+ * @brief  Set RF Band in use
+ * @param  Param string of the AT command
+ * @retval AT_OK if OK, or an appropriate AT_xxx error code
+ */
+ATEerror_t at_Band_set(const char *param);
 
 /**
  * @brief  Print Device EUI

--- a/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/inc/lora.h
+++ b/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/inc/lora.h
@@ -222,7 +222,7 @@ typedef struct sLoRaMainCallback
  * @param [IN] application parmaters
  * @retval none
  */
-void LORA_Init(LoRaMainCallback_t *callbacks, LoRaParam_t *LoRaParam);
+void LORA_Init(LoRaMainCallback_t *callbacks, LoRaParam_t *LoRaParam, LoRaMacRegion_t region);
 
 /**
  * @brief run Lora classA state Machine
@@ -387,6 +387,13 @@ int8_t lora_config_tx_datarate_get(void);
  * @retval LoRaMac region
  */
 LoRaMacRegion_t lora_region_get(void);
+
+/**
+ * @brief triggers a reinit when band gets changed
+ * @param none
+ * @retval none
+ */
+void TriggerReinit( LoRaMacRegion_t region );
 
 #ifdef __cplusplus
 }

--- a/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/src/at.c
+++ b/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/src/at.c
@@ -410,6 +410,27 @@ ATEerror_t at_AppKey_set(const char *param)
   return AT_OK;
 }
 
+extern LoRaMacRegion_t globalRegion;
+ATEerror_t at_Band_get(const char *param)
+{
+  print_d(globalRegion);
+  return AT_OK;
+}
+
+ATEerror_t at_Band_set(const char *param)
+{
+  LoRaMacRegion_t region;
+  if (tiny_sscanf(param, "%hhu", &region)  != 1)
+  {
+    return AT_PARAM_ERROR;
+  }
+  if (region != globalRegion) {
+	  globalRegion = region;
+	  TriggerReinit(globalRegion);
+  }
+  return AT_OK;
+}
+
 ATEerror_t at_NwkSKey_get(const char *param)
 {
   MibRequestConfirm_t mib;

--- a/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/src/at.c
+++ b/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/src/at.c
@@ -361,7 +361,13 @@ ATEerror_t at_JoinEUI_set(const char *param)
     return AT_PARAM_ERROR;
   }
 
+  MibRequestConfirm_t mib;
+  LoRaMacStatus_t status;
   lora_config_joineui_set(JoinEui);
+  mib.Type = MIB_JOIN_EUI;
+  mib.Param.JoinEui = JoinEui;
+  status = LoRaMacMibSetRequestConfirm(&mib);
+  CHECK_STATUS(status);
   return AT_OK;
 }
 

--- a/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/src/command.c
+++ b/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/src/command.c
@@ -109,6 +109,19 @@ static const struct ATCommand_s ATCommand[] =
   },
 #endif
 
+#ifndef NO_BAND_RUNTIME_SWITCH
+  {
+    .string = AT_BAND,
+    .size_string = sizeof(AT_BAND) - 1,
+#ifndef NO_HELP
+    .help_string = "AT"AT_BAND ": Get or Set the Regional Band\r\n",
+#endif
+    .get = at_Band_get,
+    .set = at_Band_set,
+    .run = at_return_error,
+  },
+#endif
+
 #ifndef NO_KEY_ADDR_EUI
   {
     .string = AT_APPKEY,

--- a/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/src/main.c
+++ b/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/LoRaWAN/App/src/main.c
@@ -102,7 +102,7 @@ static LoRaParam_t LoRaParamInit = {LORAWAN_ADR_ON,
                                     LORAWAN_PUBLIC_NETWORK
                                    };
 
-
+LoRaMacRegion_t globalRegion = LORAMAC_REGION_EU868;
 
 /* Private functions ---------------------------------------------------------*/
 
@@ -134,7 +134,7 @@ int main(void)
   /* USER CODE END 1 */
 
   /* Configure the Lora Stack*/
-  LORA_Init(&LoRaMainCallbacks, &LoRaParamInit);
+  LORA_Init(&LoRaMainCallbacks, &LoRaParamInit, globalRegion);
 
   /* main loop*/
   while (1)

--- a/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/SW4STM32/mlm32l07x01/.cproject
+++ b/Projects/B-L072Z-LRWAN1/Applications/LoRa/AT_Slave/SW4STM32/mlm32l07x01/.cproject
@@ -58,6 +58,15 @@
 									<listOptionValue builtIn="false" value="USE_FULL_LL_DRIVER"/>
 									<listOptionValue builtIn="false" value="NO_MAC_PRINTF"/>
 									<listOptionValue builtIn="false" value="REGION_EU868"/>
+									<listOptionValue builtIn="false" value="REGION_AS923"/>
+									<listOptionValue builtIn="false" value="REGION_AU915"/>
+									<listOptionValue builtIn="false" value="REGION_CN470"/>
+									<listOptionValue builtIn="false" value="REGION_CN779"/>
+									<listOptionValue builtIn="false" value="REGION_EU433"/>
+									<listOptionValue builtIn="false" value="REGION_IN865"/>
+									<listOptionValue builtIn="false" value="REGION_KR920"/>
+									<listOptionValue builtIn="false" value="REGION_US915"/>
+									<listOptionValue builtIn="false" value="REGION_RU864"/>
 								</option>
 								<option id="fr.ac6.managedbuild.gnu.c.compiler.option.misc.other.1826730290" superClass="fr.ac6.managedbuild.gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-fmessage-length=0" valueType="string"/>
 								<option id="gnu.c.compiler.option.dialect.std.665749972" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.default" valueType="enumerated"/>


### PR DESCRIPTION
The original version of the fw set the frequency region with a define. If the user had to change it, the firmware needed to be re-compiled and flashed with the new defined frequency. 
In order to overcome these steps, the fw has been updated to store the region as a variable. The initial band is set to the European one. Whenever a different band is selected by the user, the Lora state machine is re-initialized and the desired band of frequency is enabled.

Command "+BAND" has been added to the predefined set of AT commands to perform the band update. MKRWAN library has been updated to support this command (https://github.com/arduino-libraries/MKRWAN/pull/78).
The user can change the frequency region by using the funciton bool begin(lora_band band).

A simple test (https://github.com/giulcioffi/tests_MKRWAN) allows to continuously change the desired region, read back the frequency of the RX channel and compare it with the expected one.