### PR TITLE
Updation in HTML Tag

### DIFF
--- a/Release_Notes.html
+++ b/Release_Notes.html
@@ -1,4 +1,4 @@
-<html>
+<!DOCTYPE html>
 <head>
 <style>
 <!--
@@ -22,7 +22,7 @@ software expansion for STM32Cube
 </span></b></p>
 <p class=MsoNormal style='line-height:normal'><span style='font-size:10.0pt'>&nbsp;</span></p>
 <p class=MsoNormal align=center style='line-height:center;line-height:normal'><span style='font-size:10.0pt'>
-Copyright © 2017 STMicroelectronics
+Copyright Â© 2017 STMicroelectronics
 </span></p>
 <p class=MsoNormal align=center style='line-height:center;line-height:normal'><span style='font-size:10.0pt'>
 Microcontrollers Division - Application Team


### PR DESCRIPTION
The HTML Document Type
All HTML documents must start with a <!DOCTYPE> declaration.

The declaration is not an HTML tag. It is an "information" to the browser about what document type to expect.

In HTML5, the <!DOCTYPE> declaration is simple:

<!DOCTYPE html>
In older documents (HTML 4 or XHTML), the declaration is more complicated because the declaration must refer to a DTD (Document Type Definition).

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">