### PR TITLE
Fixe complier warnings and missing AT return states

### DIFF
--- a/Drivers/BSP/Components/sx1276/sx1276.c
+++ b/Drivers/BSP/Components/sx1276/sx1276.c
@@ -1644,8 +1644,6 @@ void SX1276OnDio0Irq( void )
                     if( ( RadioEvents != NULL ) && ( RadioEvents->RxDone != NULL ) )
                     {
                         RadioEvents->RxDone( RxTxBuffer, SX1276.Settings.LoRaPacketHandler.Size, SX1276.Settings.LoRaPacketHandler.RssiValue, SX1276.Settings.LoRaPacketHandler.SnrValue );
-                        PRINTF( "+ACK\r" );
-                        //PRINTF("+RECV=");
                     }
                 }
                 break;

--- a/Drivers/BSP/Components/sx1276/sx1276.h
+++ b/Drivers/BSP/Components/sx1276/sx1276.h
@@ -272,6 +272,11 @@ void SX1276BoardInit( LoRaBoardCallback_t *callbacks );
 uint32_t SX1276Init( RadioEvents_t *events );
 
 /*!
+ * \brief Resets the SX1276
+ */
+void SX1276Reset( void );
+
+/*!
  * \brief Sets the SX1276 operating mode
  *
  * \param [IN] opMode New operating mode

--- a/Drivers/BSP/Components/sx1276/sx1276.h
+++ b/Drivers/BSP/Components/sx1276/sx1276.h
@@ -53,6 +53,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 
 #include "sx1276Regs-Fsk.h"
 #include "sx1276Regs-LoRa.h"
+#include "radio.h"
 
 /*!
  * Radio wake-up time from sleep

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/at.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/at.h
@@ -129,6 +129,7 @@ typedef enum eATEerror
 #define AT_CERTIF     "+CERTIF"
 #define AT_CHANMASK   "+CHANMASK"
 #define AT_CHANDEFMASK "+CHANDEFMASK"
+#define AT_MSIZE	  "+MSIZE"
 
 #define AT_EVENT	  "+EVENT"
 #define AT_EQ		  "="
@@ -704,6 +705,13 @@ ATEerror_t at_ChannelDefaultMask_get(const char *param);
  * @retval AT_OK, or an appropriate AT_xxx error code
  */
 ATEerror_t at_ChannelDefaultMask_set(const char *param);
+
+/**
+ * @brief  Gets the current maximum send and receive buffer size
+ * @param  String parameter
+ * @retval AT_OK, or an appropriate AT_xxx error code
+ */
+ATEerror_t at_MaxSize_get(const char *param);
 
 #ifdef __cplusplus
 }

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/at.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/at.h
@@ -130,6 +130,7 @@ typedef enum eATEerror
 #define AT_CHANMASK   "+CHANMASK"
 #define AT_CHANDEFMASK "+CHANDEFMASK"
 
+#define AT_EVENT	  "+EVENT"
 #define AT_EQ		  "="
 
 /* Exported functions ------------------------------------------------------- */

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/at.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/at.h
@@ -130,6 +130,8 @@ typedef enum eATEerror
 #define AT_CHANMASK   "+CHANMASK"
 #define AT_CHANDEFMASK "+CHANDEFMASK"
 
+#define AT_EQ		  "="
+
 /* Exported functions ------------------------------------------------------- */
 
 /**

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/lora.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/lora.h
@@ -457,6 +457,13 @@ void lora_config_application_port_set(uint8_t application_port);
 uint8_t lora_config_application_port_get(void);
 
 /**
+ * @brief  Get the maximum payload size for tx/rx
+ * @param  None
+ * @retval Maximum size in bytes (<255)
+ */
+uint8_t lora_config_max_size_get(void);
+
+/**
  * @brief  Launch LoraWan certification tests
  * @param  None
  * @retval The application port

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/lora.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/lora.h
@@ -463,6 +463,21 @@ uint8_t lora_config_application_port_get(void);
  */
 uint8_t lora_config_max_size_get(void);
 
+
+/**
+ * @brief  Get the data rate for non-ADR send
+ * @param  None
+ * @retval Maximum size in bytes (<255)
+ */
+int8_t lora_config_data_rate_get(void);
+
+/**
+ * @brief  Set the data rate for non-ADR send
+ * @param  The data rate to set
+ * @retval None
+ */
+void lora_config_data_rate_set(int8_t data_rate);
+
 /**
  * @brief  Launch LoraWan certification tests
  * @param  None

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/lora.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/lora.h
@@ -333,9 +333,65 @@ uint8_t *lora_config_appeui_get(void);
 /**
   * @brief  Set Application EUI
   * @param  AppEUI
-  * @retval Nonoe
+  * @retval None
   */
 void lora_config_appeui_set(uint8_t appeui[8]);
+
+/**
+  * @brief  Get device address
+  * @param  None
+  * @retval DevAddr
+  */
+uint32_t lora_config_devaddr_get(void);
+
+/**
+  * @brief  Set device address
+  * @param  DevAddr
+  * @retval None
+  */
+void lora_config_devaddr_set(uint32_t devaddr);
+
+/**
+  * @brief  Set network id
+  * @param  NetId
+  * @retval None
+  */
+void lora_config_networkid_set(uint32_t networkid);
+
+/**
+  * @brief  Get network id
+  * @param  None
+  * @retval NetId
+  */
+uint32_t lora_config_networkid_get(void);
+
+/**
+  * @brief  Get network session key
+  * @param  None
+  * @retval NwkSKey
+  */
+uint8_t *lora_config_nwkskey_get(void);
+
+/**
+  * @brief  Set network session key
+  * @param  NwkSKey
+  * @retval None
+  */
+void lora_config_nwkskey_set(uint8_t nwkSKey[16]);
+
+/**
+  * @brief  Get application session key
+  * @param  None
+  * @retval AppSKey
+  */
+uint8_t *lora_config_appskey_get(void);
+
+/**
+  * @brief  Set application session key
+  * @param  AppSKey
+  * @retval None
+  */
+void lora_config_appskey_set(uint8_t appskey[16]);
 
 /**
   * @brief  Get Application Key

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/version.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/version.h
@@ -72,7 +72,7 @@ extern "C" {
 #define TEST_VERSION (uint32_t) 0x00000000  /*1 lsb is always 0 in releases   */
 #define LRWAN_VERSION  (uint32_t) 0x00001120  /*3 next hex is i_cube release*/
 #define VERSION   (uint32_t) (LORA_MAC_VERSION | LRWAN_VERSION | TEST_VERSION)
-#define AT_VERSION_STRING	"1.2.3"
+#define AT_VERSION_STRING	"1.2.4"
 #define AT_DEVICE_STRING	"ARD-078"
 
 /* Exported types ------------------------------------------------------------*/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/version.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/version.h
@@ -72,7 +72,7 @@ extern "C" {
 #define TEST_VERSION (uint32_t) 0x00000000  /*1 lsb is always 0 in releases   */
 #define LRWAN_VERSION  (uint32_t) 0x00001120  /*3 next hex is i_cube release*/
 #define VERSION   (uint32_t) (LORA_MAC_VERSION | LRWAN_VERSION | TEST_VERSION)
-#define AT_VERSION_STRING	"1.2.4"
+#define AT_VERSION_STRING	"1.2.4a"
 #define AT_DEVICE_STRING	"ARD-078"
 
 /* Exported types ------------------------------------------------------------*/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/inc/version.h
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/inc/version.h
@@ -72,7 +72,7 @@ extern "C" {
 #define TEST_VERSION (uint32_t) 0x00000000  /*1 lsb is always 0 in releases   */
 #define LRWAN_VERSION  (uint32_t) 0x00001120  /*3 next hex is i_cube release*/
 #define VERSION   (uint32_t) (LORA_MAC_VERSION | LRWAN_VERSION | TEST_VERSION)
-#define AT_VERSION_STRING	"1.2.4a"
+#define AT_VERSION_STRING	"1.2.4"
 #define AT_DEVICE_STRING	"ARD-078"
 
 /* Exported types ------------------------------------------------------------*/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -609,7 +609,7 @@ ATEerror_t at_Rx2Frequency_get(const char *param)
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
   AT_PRINTF(AT_RX2FQ AT_EQ);
-  print_d(mib.Param.Rx2Channel.Frequency);
+  print_u(mib.Param.Rx2Channel.Frequency);
 
   return AT_OK;
 }

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -457,7 +457,7 @@ ATEerror_t at_TransmitPower_set(const char *param)
   uint8_t ignored;
 
   mib.Type = MIB_CHANNELS_TX_POWER;
-  if (tiny_sscanf(param, "%hhu,%hhu", &ignored, &mib.Param.ChannelsTxPower) != 1)
+  if (tiny_sscanf(param, "%hhu,%hhu", &ignored, &mib.Param.ChannelsTxPower) != 2)
   {
     return AT_PARAM_ERROR;
   }

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -440,7 +440,7 @@ ATEerror_t at_ADR_set(const char *param)
       CHECK_STATUS(status);
 
       if (!mib.Param.AdrEnable){
-    	  mib.Type = MIB_CHANNELS_DEFAULT_DATARATE;
+    	  mib.Type = MIB_CHANNELS_DATARATE;
     	  mib.Param.ChannelsDatarate = lora_config_data_rate_get(); // apply non-ADR data rate as default to MAC layer
     	  status = LoRaMacMibSetRequestConfirm(&mib);
     	  CHECK_STATUS(status);
@@ -524,18 +524,12 @@ ATEerror_t at_DataRate_set(const char *param)
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
 
+  mib.Type = MIB_CHANNELS_DATARATE;
+  mib.Param.ChannelsDatarate = new_dr;
+  status = LoRaMacMibSetRequestConfirm(&mib);
+  CHECK_STATUS(status);
+
   if (mib.Param.AdrEnable){
-	  mib.Type = MIB_CHANNELS_DATARATE;
-	  mib.Param.ChannelsDatarate = new_dr;
-	  status = LoRaMacMibSetRequestConfirm(&mib);
-	  CHECK_STATUS(status);
-  }
-  else {
-	  // Uses MIB_CHANNELS_DEFAULT_DATARATE to test for TX possible with non ADR
-	  mib.Type = MIB_CHANNELS_DEFAULT_DATARATE;
-	  mib.Param.ChannelsDatarate = new_dr;
-	  status = LoRaMacMibSetRequestConfirm(&mib);
-	  CHECK_STATUS(status);
 	  // Set lora_config reference
 	  lora_config_data_rate_set((int8_t)new_dr);
   }

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -68,6 +68,7 @@
  * @brief Max size of the data that can be received
  */
 #define MAX_RECEIVED_DATA 255
+#define MAX_SEND_DATA	242		// LoRaWan spec 1.0.4
 
 /* Private macro -------------------------------------------------------------*/
 /**
@@ -986,7 +987,7 @@ ATEerror_t at_SendV2(const char *param)
   {
     return AT_PARAM_ERROR;
   }
-  uint8_t data[64];
+  uint8_t data[MAX_SEND_DATA];
   int i = 0;
   // grab other #len bytes from the serial buffer
   while (i<length) {
@@ -1013,7 +1014,7 @@ ATEerror_t at_SendV2Confirmation(const char *param)
   {
 	return AT_PARAM_ERROR;
   }
-  uint8_t data[64];
+  uint8_t data[MAX_SEND_DATA];
   int i = 0;
   // grab other #len bytes from the serial buffer
   while (i<length) {

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -211,7 +211,8 @@ ATEerror_t at_AppEUI_set(const char *param)
 ATEerror_t at_DevAddr_set(const char *param)
 {
 	uint32_t DevAddr;
-	sscanf_uint32_as_hhx(param, &DevAddr);
+	if (sscanf_uint32_as_hhx(param, &DevAddr) != 4)
+			return AT_PARAM_ERROR;
 
 	lora_config_devaddr_set(DevAddr);
 	return AT_OK;
@@ -235,7 +236,8 @@ ATEerror_t at_NetworkID_get(const char *param)
 ATEerror_t at_NetworkID_set(const char *param)
 {
   uint32_t NetworkID;
-  sscanf_uint32_as_hhx(param, &NetworkID);
+  if (sscanf_uint32_as_hhx(param, &NetworkID) != 4)
+			return AT_PARAM_ERROR;
 
   lora_config_networkid_set(NetworkID);
   return AT_OK;

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -524,7 +524,7 @@ ATEerror_t at_DataRate_set(const char *param)
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
 
-  if (!mib.Param.AdrEnable){
+  if (mib.Param.AdrEnable){
 	  mib.Type = MIB_CHANNELS_DATARATE;
 	  mib.Param.ChannelsDatarate = new_dr;
 	  status = LoRaMacMibSetRequestConfirm(&mib);

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -68,7 +68,7 @@
  * @brief Max size of the data that can be received
  */
 #define MAX_RECEIVED_DATA 255
-#define MAX_SEND_DATA	242		// LoRaWan spec 1.0.4
+#define MAX_SEND_DATA	484		// LoRaWan spec 1.0.4 = 242*2 (used for binary send HEX chars)
 
 /* Private macro -------------------------------------------------------------*/
 /**
@@ -1011,7 +1011,8 @@ ATEerror_t at_SendV2(const char *param)
 
   size_t length = 0;
 
-  if (tiny_sscanf(param, "%hhu", &length) != 1)
+  if (tiny_sscanf(param, "%hu", &length) != 1
+		  || length > MAX_SEND_DATA)
   {
     return AT_PARAM_ERROR;
   }
@@ -1038,7 +1039,8 @@ ATEerror_t at_SendV2Confirmation(const char *param)
 
   size_t length = 0;
 
-  if (tiny_sscanf(param, "%hhu", &length) != 1)
+  if (tiny_sscanf(param, "%hu", &length) != 1
+		  || length > MAX_SEND_DATA)
   {
 	return AT_PARAM_ERROR;
   }

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -888,14 +888,11 @@ ATEerror_t at_NetworkJoinStatus(const char *param)
 
   mibReq.Type = MIB_NETWORK_JOINED;
   status = LoRaMacMibGetRequestConfirm(&mibReq);
+  CHECK_STATUS(status);
 
-  if (status == LORAMAC_STATUS_OK)
-  {
-	AT_PRINTF("+OK=");
-    print_d(mibReq.Param.IsNetworkJoined ? 1 : 0);
-    return AT_OK;
-  }
-  return AT_ERROR;
+  AT_PRINTF("+OK=");
+  print_d(mibReq.Param.IsNetworkJoined ? 1 : 0);
+  return AT_OK;
 }
 
 ATEerror_t at_SendBinary(const char *param)

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -669,6 +669,7 @@ ATEerror_t at_Rx2Delay_get(const char *param)
   mib.Type = MIB_RECEIVE_DELAY_2;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
+  AT_PRINTF("+OK=");
   print_u(mib.Param.ReceiveDelay2);
 
   return AT_OK;
@@ -891,7 +892,8 @@ ATEerror_t at_NetworkJoinStatus(const char *param)
   CHECK_STATUS(status);
 
   AT_PRINTF("+OK=");
-  print_d(mibReq.Param.IsNetworkJoined ? 1 : 0);
+  print_d((mibReq.Param.IsNetworkJoined) ? 1 : 0);
+
   return AT_OK;
 }
 
@@ -1090,30 +1092,35 @@ ATEerror_t at_ack_set(const char *param)
 
 ATEerror_t at_ack_get(const char *param)
 {
+  AT_PRINTF("+OK=");
   print_d (((lora_config_reqack_get() == ENABLE) ? 1 : 0));
   return AT_OK;
 }
 
 ATEerror_t at_isack_get(const char *param)
 {
+  AT_PRINTF("+OK=");
   print_d(((lora_config_isack_get() == ENABLE) ? 1 : 0));
   return AT_OK;
 }
 
 ATEerror_t at_snr_get(const char *param)
 {
+  AT_PRINTF("+OK=");
   print_u(lora_config_snr_get());
   return AT_OK;
 }
 
 ATEerror_t at_rssi_get(const char *param)
 {
+  AT_PRINTF("+OK=");
   print_d(lora_config_rssi_get());
   return AT_OK;
 }
 
 ATEerror_t at_bat_get(const char *param)
 {
+  AT_PRINTF("+OK=");
   print_u(HW_GetBatteryLevel());
   return AT_OK;
 }

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -182,14 +182,14 @@ ATEerror_t at_reset(const char *param)
 
 ATEerror_t at_DevEUI_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_DEUI AT_EQ);
   print_8_02x(lora_config_deveui_get());
   return AT_OK;
 }
 
 ATEerror_t at_AppEUI_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_APPEUI AT_EQ);
   print_8_02x(lora_config_appeui_get());
   return AT_OK;
 }
@@ -220,14 +220,14 @@ ATEerror_t at_DevAddr_set(const char *param)
 ATEerror_t at_DevAddr_get(const char *param)
 {
 
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_DADDR AT_EQ);
   print_uint32_as_02x(lora_config_devaddr_get());
   return AT_OK;
 }
 
 ATEerror_t at_NetworkID_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_NWKID AT_EQ);
   print_uint32_as_02x(lora_config_networkid_get());
   return AT_OK;
 }
@@ -243,7 +243,7 @@ ATEerror_t at_NetworkID_set(const char *param)
 
 ATEerror_t at_AppKey_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_APPKEY AT_EQ);
   print_16_02x(lora_config_appkey_get());
   return AT_OK;
 }
@@ -264,7 +264,7 @@ ATEerror_t at_AppKey_set(const char *param)
 extern LoRaMacRegion_t globalRegion;
 ATEerror_t at_Band_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_BAND AT_EQ);
   print_d(globalRegion);
   return AT_OK;
 }
@@ -285,7 +285,7 @@ ATEerror_t at_Band_set(const char *param)
 
 ATEerror_t at_NwkSKey_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_NWKSKEY AT_EQ);
   print_16_02x(lora_config_nwkskey_get());
   return AT_OK;
 }
@@ -305,7 +305,7 @@ ATEerror_t at_NwkSKey_set(const char *param)
 
 ATEerror_t at_AppSKey_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_APPSKEY AT_EQ);
   print_16_02x(lora_config_appskey_get());
   return AT_OK;
 }
@@ -337,7 +337,7 @@ ATEerror_t at_ChannelMask_get(const char *param)
   mib.Type = MIB_CHANNELS_MASK;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_CHANMASK AT_EQ);
   AT_PRINTF("%04x%04x%04x%04x%04x%04x\r",
           mib.Param.ChannelsMask[0], mib.Param.ChannelsMask[1], mib.Param.ChannelsMask[2], mib.Param.ChannelsMask[3],
      mib.Param.ChannelsMask[4], mib.Param.ChannelsMask[5]);
@@ -372,7 +372,7 @@ ATEerror_t at_ChannelDefaultMask_get(const char *param)
   mib.Type = MIB_CHANNELS_DEFAULT_MASK;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_CHANDEFMASK AT_EQ);
   AT_PRINTF("%04x%04x%04x%04x%04x%04x\r",
           mib.Param.ChannelsDefaultMask[0], mib.Param.ChannelsDefaultMask[1], mib.Param.ChannelsDefaultMask[2], mib.Param.ChannelsDefaultMask[3],
      mib.Param.ChannelsDefaultMask[4], mib.Param.ChannelsDefaultMask[5]);
@@ -408,7 +408,7 @@ ATEerror_t at_ADR_get(const char *param)
   mib.Type = MIB_ADR;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_ADR AT_EQ);
   print_d(mib.Param.AdrEnable);
 
   return AT_OK;
@@ -444,7 +444,7 @@ ATEerror_t at_TransmitPower_get(const char *param)
   mib.Type = MIB_CHANNELS_TX_POWER;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_TXP AT_EQ);
   print_d(mib.Param.ChannelsTxPower);
 
   return AT_OK;
@@ -476,7 +476,7 @@ ATEerror_t at_DataRate_get(const char *param)
 
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_DR AT_EQ);
   print_d(mib.Param.ChannelsDatarate);
 
   return AT_OK;
@@ -517,7 +517,7 @@ ATEerror_t at_DutyCycle_set(const char *param)
 
 ATEerror_t at_DutyCycle_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_DCS AT_EQ);
   if (lora_config_duty_cycle_get() == ENABLE)
     AT_PRINTF("1\r");
   else
@@ -535,7 +535,7 @@ ATEerror_t at_PublicNetwork_get(const char *param)
   mib.Type = MIB_PUBLIC_NETWORK;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_PNM AT_EQ);
   print_d(mib.Param.EnablePublicNetwork);
 
   return AT_OK;
@@ -570,7 +570,7 @@ ATEerror_t at_Rx2Frequency_get(const char *param)
   mib.Type = MIB_RX2_CHANNEL;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_RX2FQ AT_EQ);
   print_d(mib.Param.Rx2Channel.Frequency);
 
   return AT_OK;
@@ -604,7 +604,7 @@ ATEerror_t at_Rx2DataRate_get(const char *param)
   mib.Type = MIB_RX2_CHANNEL;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_RX2DR AT_EQ);
   print_d(mib.Param.Rx2Channel.Datarate);
 
   return AT_OK;
@@ -639,7 +639,7 @@ ATEerror_t at_Rx1Delay_get(const char *param)
   mib.Type = MIB_RECEIVE_DELAY_1;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_RX1DL AT_EQ);
   print_u(mib.Param.ReceiveDelay1);
 
   return AT_OK;
@@ -669,7 +669,7 @@ ATEerror_t at_Rx2Delay_get(const char *param)
   mib.Type = MIB_RECEIVE_DELAY_2;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_RX2DL AT_EQ);
   print_u(mib.Param.ReceiveDelay2);
 
   return AT_OK;
@@ -699,7 +699,7 @@ ATEerror_t at_JoinAcceptDelay1_get(const char *param)
   mib.Type = MIB_JOIN_ACCEPT_DELAY_1;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_JN1DL AT_EQ);
   print_u(mib.Param.JoinAcceptDelay1);
 
   return AT_OK;
@@ -729,7 +729,7 @@ ATEerror_t at_JoinAcceptDelay2_get(const char *param)
   mib.Type = MIB_JOIN_ACCEPT_DELAY_2;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_JN2DL AT_EQ);
   print_u(mib.Param.JoinAcceptDelay2);
 
   return AT_OK;
@@ -753,7 +753,7 @@ ATEerror_t at_JoinAcceptDelay2_set(const char *param)
 
 ATEerror_t at_NetworkJoinMode_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_NJM AT_EQ);
   print_d((lora_config_otaa_get() == ENABLE ? 1 : 0));
   return AT_OK;
 }
@@ -786,7 +786,7 @@ ATEerror_t at_UplinkCounter_get(const char *param)
   mib.Type = MIB_UPLINK_COUNTER;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_FCU AT_EQ);
   print_u(mib.Param.UpLinkCounter);
 
   return AT_OK;
@@ -816,7 +816,7 @@ ATEerror_t at_DownlinkCounter_get(const char *param)
   mib.Type = MIB_DOWNLINK_COUNTER;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_FCD AT_EQ);
   print_u(mib.Param.DownLinkCounter);
 
   return AT_OK;
@@ -846,7 +846,7 @@ ATEerror_t at_DeviceClass_get(const char *param)
   mib.Type = MIB_DEVICE_CLASS;
   status = LoRaMacMibGetRequestConfirm(&mib);
   CHECK_STATUS(status);
-  AT_PRINTF("+OK=%c\r", 'A' + mib.Param.Class);
+  AT_PRINTF(AT_CLASS AT_EQ "%c\r", 'A' + mib.Param.Class);
 
   return AT_OK;
 }
@@ -891,7 +891,7 @@ ATEerror_t at_NetworkJoinStatus(const char *param)
   status = LoRaMacMibGetRequestConfirm(&mibReq);
   CHECK_STATUS(status);
 
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_NJS AT_EQ);
   print_d((mibReq.Param.IsNetworkJoined) ? 1 : 0);
 
   return AT_OK;
@@ -921,7 +921,7 @@ ATEerror_t at_ReceiveBinary(const char *param)
 {
   unsigned i;
 
-  AT_PRINTF("+RECV=");
+  AT_PRINTF(AT_RECVB AT_EQ);
   AT_PRINTF("%d,%d\r\n\n", ReceivedDataPort, ReceivedDataSize);
 
   for (i = 0; i < ReceivedDataSize; i++)
@@ -942,10 +942,9 @@ static uint8_t format_send_v2 = USE_HEX;
 ATEerror_t at_Receive(const char *param)
 {
 
-  AT_PRINTF("+RECV=");
-
   if (format_send_v2==0)
   {
+	  AT_PRINTF(AT_RECV AT_EQ);
 	  AT_PRINTF("%d,%d\r\n\n", ReceivedDataPort, ReceivedDataSize);
 	  for (unsigned i = 0; i < ReceivedDataSize; i++)
 	  {
@@ -954,6 +953,7 @@ ATEerror_t at_Receive(const char *param)
   }
   else
   {
+	  AT_PRINTF(AT_RECVB AT_EQ);
 	  AT_PRINTF("%d,%d\r\n\n", ReceivedDataPort, ReceivedDataSize*2);
 	  for (unsigned i = 0; i < ReceivedDataSize; i++)
 	  {
@@ -1022,7 +1022,7 @@ ATEerror_t at_SendV2Confirmation(const char *param)
 
 ATEerror_t at_Port_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_PORT AT_EQ);
   print_u(lora_config_application_port_get());
 
   return AT_OK;
@@ -1043,7 +1043,7 @@ ATEerror_t at_Port_set(const char *param)
 
 ATEerror_t at_Format_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_FORMAT AT_EQ);
   print_u(format_send_v2);
 
   return AT_OK;
@@ -1061,14 +1061,14 @@ ATEerror_t at_Format_set(const char *param)
 
 ATEerror_t at_version_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_VER AT_EQ);
   AT_PRINTF(AT_VERSION_STRING"\r");
   return AT_OK;
 }
 
 ATEerror_t at_device_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_DEV AT_EQ);
   AT_PRINTF(AT_DEVICE_STRING"\r");
   return AT_OK;
 }
@@ -1092,35 +1092,35 @@ ATEerror_t at_ack_set(const char *param)
 
 ATEerror_t at_ack_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_CFM AT_EQ);
   print_d (((lora_config_reqack_get() == ENABLE) ? 1 : 0));
   return AT_OK;
 }
 
 ATEerror_t at_isack_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_CFS AT_EQ);
   print_d(((lora_config_isack_get() == ENABLE) ? 1 : 0));
   return AT_OK;
 }
 
 ATEerror_t at_snr_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_SNR AT_EQ);
   print_u(lora_config_snr_get());
   return AT_OK;
 }
 
 ATEerror_t at_rssi_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_RSSI AT_EQ);
   print_d(lora_config_rssi_get());
   return AT_OK;
 }
 
 ATEerror_t at_bat_get(const char *param)
 {
-  AT_PRINTF("+OK=");
+  AT_PRINTF(AT_BAT AT_EQ);
   print_u(HW_GetBatteryLevel());
   return AT_OK;
 }

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/at.c
@@ -402,6 +402,13 @@ ATEerror_t at_ChannelDefaultMask_set(const char *param)
   return AT_OK;
 }
 
+ATEerror_t at_MaxSize_get (const char *param)
+{
+  AT_PRINTF(AT_MSIZE AT_EQ);
+  print_u(lora_config_max_size_get());
+  return AT_OK;
+}
+
 ATEerror_t at_ADR_get(const char *param)
 {
   MibRequestConfirm_t mib;

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/command.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/command.c
@@ -655,6 +655,17 @@ static const struct ATCommand_s ATCommand[] =
     .set = at_ChannelDefaultMask_set,
     .run = at_return_error,
   },
+
+  {
+    .string = AT_MSIZE,
+    .size_string = sizeof(AT_MSIZE) - 1,
+#ifndef NO_HELP
+    .help_string = "AT"AT_MSIZE ": Retreives the actual maximum size for RX/TX messages\r\n",
+#endif
+    .get = at_MaxSize_get,
+    .set = at_return_error,
+    .run = at_return_error,
+  },
 };
 
 

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
@@ -1088,4 +1088,11 @@ uint8_t lora_config_application_port_get(void)
   return lora_config.application_port;
 }
 
+uint8_t lora_config_max_size_get(void)
+{
+  LoRaMacTxInfo_t txInfo;
+  (void)LoRaMacQueryTxPossible( 0, &txInfo );
+  return txInfo.MaxPossiblePayload;
+}
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
@@ -125,7 +125,7 @@ static uint32_t DevAddr = LORAWAN_DEVICE_ADDRESS;
 /*!
  * User application data buffer size
  */
-#define LORAWAN_APP_DATA_BUFF_SIZE                           64
+#define LORAWAN_APP_DATA_BUFF_SIZE		242	//   max length for transmission LoRaWan 1.0.4
 
 /*!
  * User application data

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
@@ -241,6 +241,7 @@ static bool SendFrame( void )
     {
         // Send empty frame in order to flush MAC commands
         mcpsReq.Type = MCPS_UNCONFIRMED;
+        mcpsReq.Req.Unconfirmed.fPort = 0;
         mcpsReq.Req.Unconfirmed.fBuffer = NULL;
         mcpsReq.Req.Unconfirmed.fBufferSize = 0;
         mcpsReq.Req.Unconfirmed.Datarate = LoRaParamInit->TxDatarate;

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
@@ -1095,4 +1095,12 @@ uint8_t lora_config_max_size_get(void)
   return txInfo.MaxPossiblePayload;
 }
 
+int8_t lora_config_data_rate_get(void){
+	return LoRaParamInit->TxDatarate;
+}
+
+void lora_config_data_rate_set(int8_t data_rate){
+	LoRaParamInit->TxDatarate = data_rate;
+}
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
@@ -654,20 +654,17 @@ LoRaMacStatus_t lora_join(void)
  */
 LoRaMacStatus_t lora_send(const char *buf, unsigned bufSize, unsigned binary, unsigned raw)
 {
+  if (raw == 1)
+	  goto on_raw;
+
   uint32_t appport;
 
-  if (raw == 1) {
-	  goto on_raw;
-  }
   /* read and set the application port */
   if (1 != tiny_sscanf(buf, "%u:", &appport))
   {
     PRINTF("AT+SEND without the application port");
     return LORAMAC_STATUS_PARAMETER_INVALID;
   }
-  
-  /* set the application port to send to */
-  lora_config_application_port_set(appport);
 
   /* skip the application port */
   while (('0' <= buf[0]) && (buf[0] <= '9'))
@@ -682,7 +679,10 @@ LoRaMacStatus_t lora_send(const char *buf, unsigned bufSize, unsigned binary, un
   }
   buf ++;
   bufSize --;
-  
+
+  /* set the application port to send to */
+  lora_config_application_port_set(appport);
+
 on_raw:
   OnSendEvent();
 

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/lora.c
@@ -64,6 +64,7 @@ Maintainer: Miguel Luis, Gregory Cristian and Wael Guibene
 #include "LoRaMac.h"
 #include "lora.h"
 #include "tiny_sscanf.h"
+#include "at.h"
 
 static lora_configuration_t lora_config = 
 {
@@ -880,7 +881,7 @@ void lora_fsm( LoRaMacRegion_t region )
     }
     case DEVICE_STATE_JOINED:
     {
-      PRINTF("+EVENT=1,1\r");
+      PRINTF(AT_EVENT AT_EQ "1,1\r");
       DeviceState = DEVICE_STATE_SLEEP;
       break;
     }

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
@@ -297,7 +297,7 @@ int main(void)
 
   /* USER CODE BEGIN 1 */
   CMD_Init();
-  PRINTF(AT_EVENT AT_EQ "0,0");
+  PRINTF(AT_EVENT AT_EQ "0,0\r");
   /* USER CODE END 1 */
 
   /* Configure the Lora Stack*/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
@@ -66,7 +66,6 @@ Maintainer: Miguel Luis, Gregory Cristian and Wael Guibene
 #include "version.h"
 #include "command.h"
 #include "at.h"
-//#include "lora.h"
 #include "sx1276.h"
 
 /* Private typedef -----------------------------------------------------------*/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
@@ -297,7 +297,7 @@ int main(void)
 
   /* USER CODE BEGIN 1 */
   CMD_Init();
-  PRINTF("+EVENT=0,0");
+  PRINTF(AT_EVENT AT_EQ "0,0");
   /* USER CODE END 1 */
 
   /* Configure the Lora Stack*/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/main.c
@@ -66,7 +66,8 @@ Maintainer: Miguel Luis, Gregory Cristian and Wael Guibene
 #include "version.h"
 #include "command.h"
 #include "at.h"
-#include "lora.h"
+//#include "lora.h"
+#include "sx1276.h"
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/

--- a/Projects/Multi/Applications/LoRa/AT_Slave/src/vcom.c
+++ b/Projects/Multi/Applications/LoRa/AT_Slave/src/vcom.c
@@ -341,7 +341,7 @@ void vcom_IRQHandler(void)
 
   if (LL_LPUART_IsActiveFlag_PE(UARTX) || LL_LPUART_IsActiveFlag_FE(UARTX) || LL_LPUART_IsActiveFlag_ORE(UARTX) || LL_LPUART_IsActiveFlag_NE(UARTX))
   {
-    PRINTF("Error when receiving\n");
+    // PRINTF("Error when receiving\n"); Using return code
     /* clear error IT */
     LL_LPUART_ClearFlag_PE(UARTX);
     LL_LPUART_ClearFlag_FE(UARTX);

--- a/README.md
+++ b/README.md
@@ -4,11 +4,34 @@ This package contains the firmware for Murata CMWX1ZZABZ-078 module.
 
 It is derived from [I-CUBE-LRWAN](http://www.st.com/en/embedded-software/i-cube-lrwan.html), with some new APIs (like the ability to switch band at runtime, not only at compile time).
 
-The project is provided a [System Workbench for STM32](http://www.openstm32.org/System%2BWorkbench%2Bfor%2BSTM32) project, but can also be compiled in Eclipse after following [this](http://www.openstm32.org/Installing%2BSystem%2BWorkbench%2Bfor%2BSTM32%2Bfrom%2BEclipse#Important_note_about_your_MAC_OSX_host_version) guide
-
 [Releases](https://github.com/bcmi-labs/mkrwan1300-fw/releases) contains the precompiled firmware that can be uploaded either using FWUpdaterBridge or MKRWANFWUpdate_standalone examples from in https://github.com/arduino-libraries/MKRWAN
 
 All the code maintains its original license.
+
+## Compiling the code 
+The project is provided a [System Workbench for STM32](http://www.openstm32.org/System%2BWorkbench%2Bfor%2BSTM32) project, but can also be compiled in Eclipse after following [this](http://www.openstm32.org/Installing%2BSystem%2BWorkbench%2Bfor%2BSTM32%2Bfrom%2BEclipse#Important_note_about_your_MAC_OSX_host_version) guide. A third alternative is using Docker containers. Enter the following in a file called `Dockerfile`
+
+```
+FROM stronglytyped/arm-none-eabi-gcc:latest
+
+#Buildkit for hex file
+RUN apt-get update && \
+	apt install -y xxd \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /home
+CMD ["make", "-B"]
+```
+Then you create the new container image by running the build in the directory with `Dockerfile`. Let's name the image `arm-eabi-mkr`.
+```
+docker build . -t arm-eabi-mkr
+```
+Once you built the Docker image you can use the _Docker tooling_ add-on in Eclipse to build the firmware. Open the source code as CDT project and set the build container to `arm-eabi-mkr` in _Properties>C/C++ Build>Settings_.
+Alternatively, enter the source directory and run a container mapping the source directory to home as follows:
+```
+docker run -rm -v "$PWD":/home arm-eabi-mkr 
+```
+The `-rm` option removes the container after execution, while `-v` sets the directory mapping from `$PWD`, i.e., local directory, to `/home` inside the container.
 
 ## AT Command List
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ docker run -rm -v "$PWD":/home arm-eabi-mkr
 ```
 The `-rm` option removes the container after execution, while `-v` sets the directory mapping from `$PWD`, i.e., local directory, to `/home` inside the container.
 
+The file `fw.h` contains now the new firmware to be flashed, e.g., with the standalone sketch in the MKRWAN library. Just replace the included file and run the sketch on your device.
+
+## Backwards compatibility
+
+Starting from FW 1.2.4, the modem responds to value requests with the command followed by the value, e.g., `+FCU=3` instead of `+OK=3`.  Thus, to use newer firmware, you need to use a compatible, recent library. 
+
 ## AT Command List
 
 | Command      | Description

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker build . -t arm-eabi-mkr
 Once you built the Docker image you can use the _Docker tooling_ add-on in Eclipse to build the firmware. Open the source code as CDT project and set the build container to `arm-eabi-mkr` in _Properties>C/C++ Build>Settings_.
 Alternatively, enter the source directory and run a container mapping the source directory to home as follows:
 ```
-docker run -rm -v "$PWD":/home arm-eabi-mkr 
+docker run --rm -v "$PWD":/home arm-eabi-mkr 
 ```
 The `-rm` option removes the container after execution, while `-v` sets the directory mapping from `$PWD`, i.e., local directory, to `/home` inside the container.
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ All the code maintains its original license.
 | AT+CERTIF    | Set the module in LoraWan Certification Mode |
 | AT+CFM       | Get or Set the confirmation mode (0-1) |
 | AT+CFS       | Get confirmation status of the last AT+SEND (0-1) |
+| AT+CHANMASK  | Gets the current region's channel mask, note this is reset when changing regions |
+| AT+CHANDEFMASK | Gets the current region's default mask, note this is reset when changing regions |  |
 | AT+CLASS     | Get or Set the Device Class |
 | AT+CTX       | send with confirmation |
 | AT+DEV       | Get the version of the AT_Slave FW |
 | AT+DEVADDR   | Get or Set the Device address |
 | AT+DEVEUI    | Get the Device EUI |
 | AT+DFORMAT   | select hex or binary format |
-| AT+DR        | Get or Set the Data Rate. (0-7 corresponding to DR_X) |
+| AT+DR        | Get or Set the Data Rate. (0-7 corresponding to DR_X). If ADR is off, it sets also the default data rate |
 | AT+DUTYCYCLE | Get or Set the ETSI Duty Cycle setting - 0=disable, 1=enable - Only for testing |
 | AT+FCD       | Get or Set the Frame Counter Downlink |
 | AT+FCU       | Get or Set the Frame Counter Uplink |
@@ -38,6 +40,7 @@ All the code maintains its original license.
 | AT+JN2DL     | Get or Set the Join Accept Delay between the end of the Tx and the Join Rx Window 2 in ms |
 | AT+JOIN      | Join network |
 | AT+MODE      | Get or Set the Network Join Mode. (0: ABP, 1: OTAA) |
+| AT+MSIZE     | Get the maximum send/receive size for the actual data rate |
 | AT+NJS       | Get the join status |
 | AT+NWK       | Get or Set the public network mode. (0: off, 1: on) |
 | AT+NWKSKEY   | Get or Set the Network Session Key |
@@ -62,5 +65,3 @@ All the code maintains its original license.
 | AT+TTONE     | Starts RF Tone test |
 | AT+UTX       | send without confirmation |
 | AT+VER       | Get the version of the AT_Slave FW|
-| AT+CHANMASK  | Gets the current region's channel mask, note this is reset when changing regions |
-| AT+CHANDEFMASK | Gets the current region's default mask, note this is reset when changing regions |  |


### PR DESCRIPTION
This merge addresses two issues: 

When compiling the firmware I noted missing function declarations and includes. Fixed, added them in `lora.h`, `main.c` and sx1276.h`

Added also the missing `+OK=` AT responses for the getters in ATslave in `at.c` (`+RSSI`, `+SNR`...)
